### PR TITLE
Prevent cursor from becoming stuck in move style

### DIFF
--- a/src/interactions.js
+++ b/src/interactions.js
@@ -27,9 +27,10 @@ const onMove = (event) => {
 
 const setupDrag = (element, { dragArea }) => interact(element, {
     ignoreFrom: '.bar-container',
+    styleCursor: false,
   })
   .draggable({
-    enagle: true,
+    enabled: true,
     inertia: true,
     autoScroll: false,
     restrict: {


### PR DESCRIPTION
This occurred when interacting with the player. Interact.js thought it was supposed to be a grad and converted the cursor to move.